### PR TITLE
Add support for OS X SDK

### DIFF
--- a/jive-ios-sdk.podspec
+++ b/jive-ios-sdk.podspec
@@ -6,16 +6,19 @@ Pod::Spec.new do |s|
     s.homepage      = "https://github.com/jivesoftware/jive-ios-sdk"
     s.authors       = { "Jive Mobile" => "jive-mobile@jivesoftware.com" }
     s.source_files  = "jive-ios-sdk/JiveiOSSDKVersion.h","jive-ios-sdk/**/*.{h,m}","lib/JiveObjcRuntime.{h,m}","lib/google-toolbox-for-mac/Foundation/*.{h,m}"
-    s.frameworks    = "Foundation", "MobileCoreServices", "SystemConfiguration"
     s.source        = { :git => "git@git.jiveland.com:jive-ios-sdk", :tag => "v#{s.version}" }
     s.requires_arc  = true
-    s.platform      = :ios
-    s.ios.deployment_target = "6.0"
     s.header_dir    = "Jive"
     s.public_header_files = "jive-ios-sdk/**/*.{h},lib/google-toolbox-for-mac/Foundation/*.{h}"
     s.private_header_files = "jive-ios-sdk/JiveKVOAdapter.h","jive-ios-sdk/NSDateFormatter+JiveISO8601DateFormatter.h","jive-ios-sdk/JiveRetryingURLConnectionOperation.h","jive-ios-sdk/JiveRetryingInner*.h","jive-ios-sdk/entity/JiveTargetList_internal.h","jive-ios-sdk/entity/JiveTypedObject_internal.h","jive-ios-sdk/JAPIRequestOperation.h","jive-ios-sdk/JiveRetrying*HTTPRequestOperation.h","jive-ios-sdk/JiveRetrying*APIRequestOperation.h","jive-ios-sdk/JiveRetryingURLConnectionOperation*.h"
     s.prefix_header_file = "jive-ios-sdk/jive-ios-sdk-Prefix.pch"
     s.dependency    "AFNetworking", "1.2.1"
+
+    s.ios.deployment_target = "6.0"
+    s.ios.frameworks        = "MobileCoreServices", "SystemConfiguration"
+    
+    s.osx.deployment_target = "10.8"
+    s.osx.frameworks        = "CoreServices", "SystemConfiguration"
     
     # Disable arc
     s.subspec "no-arc" do |na|

--- a/jive-ios-sdk/Jive.h
+++ b/jive-ios-sdk/Jive.h
@@ -218,7 +218,7 @@ typedef void (^JiveBadRequestLoggerBlock)(NSString *message, Jive *jive, NSURLRe
 //! https://developers.jivesoftware.com/api/v3/rest/PersonService.html#deletePerson(String,%20UriInfo)
 - (void) deletePerson:(JivePerson *)person onComplete:(void (^)(void))complete onError:(JiveErrorBlock)error;
 //! https://developers.jivesoftware.com/api/v3/rest/PersonService.html#getAvatar(String)
-- (void) avatarForPerson:(JivePerson *)person onComplete:(void (^)(UIImage *avatarImage))complete onError:(JiveErrorBlock)error;
+- (void) avatarForPerson:(JivePerson *)person onComplete:(JiveImageCompleteBlock)complete onError:(JiveErrorBlock)error;
 //! https://developers.jivesoftware.com/api/v3/rest/PersonService.html#updatePerson(String,%20PersonEntity)
 - (void) updatePerson:(JivePerson *)person onComplete:(void (^)(JivePerson *))complete onError:(JiveErrorBlock)error;
 //! https://developers.jivesoftware.com/api/v3/rest/PersonService.html#createFollowing(String,%20String)
@@ -276,7 +276,7 @@ typedef void (^JiveBadRequestLoggerBlock)(NSString *message, Jive *jive, NSURLRe
 //! https://developers.jivesoftware.com/api/v3/rest/PersonService.html#deletePerson(String,%20UriInfo)
 - (AFJSONRequestOperation<JiveRetryingOperation> *) deletePersonOperation:(JivePerson *)person onComplete:(void (^)(void))complete onError:(JiveErrorBlock)error;
 //! https://developers.jivesoftware.com/api/v3/rest/PersonService.html#getAvatar(String)
-- (AFImageRequestOperation<JiveRetryingOperation> *) avatarForPersonOperation:(JivePerson *)person onComplete:(void (^)(UIImage *avatarImage))complete onError:(JiveErrorBlock)errorBlock;
+- (AFImageRequestOperation<JiveRetryingOperation> *) avatarForPersonOperation:(JivePerson *)person onComplete:(JiveImageCompleteBlock)complete onError:(JiveErrorBlock)errorBlock;
 //! https://developers.jivesoftware.com/api/v3/rest/PersonService.html#updatePerson(String,%20PersonEntity)
 - (AFJSONRequestOperation<JiveRetryingOperation> *) updatePersonOperation:(JivePerson *)person onComplete:(void (^)(JivePerson *))complete onError:(JiveErrorBlock)error;
 //! https://developers.jivesoftware.com/api/v3/rest/PersonService.html#createFollowing(String,%20String)
@@ -390,7 +390,7 @@ typedef void (^JiveBadRequestLoggerBlock)(NSString *message, Jive *jive, NSURLRe
 //! https://developers.jivesoftware.com/api/v3/rest/PlaceService.html#getPlaceAnnouncements(String,%20int,%20int,%20boolean,%20String)
 - (void) announcementsForPlace:(JivePlace *)place options:(JivePagedRequestOptions *)options onComplete:(void (^)(NSArray *announcements))completeBlock onError:(JiveErrorBlock)errorBlock;
 //! https://developers.jivesoftware.com/api/v3/rest/PlaceService.html#getPlaceAvatar(String,%20String)
-- (void) avatarForPlace:(JivePlace *)place options:(JiveDefinedSizeRequestOptions *)options onComplete:(void (^)(UIImage *avatarImage))completeBlock onError:(JiveErrorBlock)errorBlock;
+- (void) avatarForPlace:(JivePlace *)place options:(JiveDefinedSizeRequestOptions *)options onComplete:(JiveImageCompleteBlock)completeBlock onError:(JiveErrorBlock)errorBlock;
 //! https://developers.jivesoftware.com/api/v3/rest/PlaceService.html#getPlaceTasks(String,%20String,%20int,%20int,%20String)
 - (void) tasksForPlace:(JivePlace *)place options:(JiveSortedRequestOptions *)options onComplete:(void (^)(NSArray *tasks))completeBlock onError:(JiveErrorBlock)errorBlock;
 
@@ -427,7 +427,7 @@ typedef void (^JiveBadRequestLoggerBlock)(NSString *message, Jive *jive, NSURLRe
 //! https://developers.jivesoftware.com/api/v3/rest/PlaceService.html#getPlaceAnnouncements(String,%20int,%20int,%20boolean,%20String)
 - (AFJSONRequestOperation<JiveRetryingOperation> *) announcementsOperationForPlace:(JivePlace *)place options:(JivePagedRequestOptions *)options onComplete:(void (^)(NSArray *announcements))completeBlock onError:(JiveErrorBlock)errorBlock;
 //! https://developers.jivesoftware.com/api/v3/rest/PlaceService.html#getPlaceAvatar(String,%20String)
-- (AFImageRequestOperation<JiveRetryingOperation> *) avatarOperationForPlace:(JivePlace *)place options:(JiveDefinedSizeRequestOptions *)options onComplete:(void (^)(UIImage *avatarImage))completeBlock onError:(JiveErrorBlock)errorBlock;
+- (AFImageRequestOperation<JiveRetryingOperation> *) avatarOperationForPlace:(JivePlace *)place options:(JiveDefinedSizeRequestOptions *)options onComplete:(JiveImageCompleteBlock)completeBlock onError:(JiveErrorBlock)errorBlock;
 //! https://developers.jivesoftware.com/api/v3/rest/PlaceService.html#getPlaceTasks(String,%20String,%20int,%20int,%20String)
 - (AFJSONRequestOperation<JiveRetryingOperation> *) tasksOperationForPlace:(JivePlace *)place options:(JiveSortedRequestOptions *)options onComplete:(void (^)(NSArray *tasks))completeBlock onError:(JiveErrorBlock)errorBlock;
 
@@ -642,22 +642,22 @@ typedef void (^JiveBadRequestLoggerBlock)(NSString *message, Jive *jive, NSURLRe
 //! https://developers.jivesoftware.com/api/v3/rest/ImageService.html#getContentImages(String,%20String)
 - (void)imagesFromURL:(NSURL *)imagesURL onComplete:(void (^)(NSArray *images))completeBlock onError:(JiveErrorBlock)errorBlock;
 //! https://developers.jivesoftware.com/api/v3/rest/ImageService.html#uploadImage(MultipartBody)
-- (void) uploadImage:(UIImage*) image onComplete:(void (^)(JiveImage*))complete onError:(JiveErrorBlock) errorBlock;
+- (void) uploadImage:(JiveNativeImage*) image onComplete:(void (^)(JiveImage*))complete onError:(JiveErrorBlock) errorBlock;
 //! https://developers.jivesoftware.com/api/v3/rest/ImageService.html#uploadImage(MultipartBody)
-- (void)uploadJPEGImage:(UIImage *)image onComplete:(void (^)(JiveImage *))complete onError:(JiveErrorBlock) errorBlock;
+- (void)uploadJPEGImage:(JiveNativeImage *)image onComplete:(void (^)(JiveImage *))complete onError:(JiveErrorBlock) errorBlock;
 //! https://developers.jivesoftware.com/api/v3/rest/ImageService.html#uploadImage(MultipartBody)
-- (void)uploadPNGImage:(UIImage *)image onComplete:(void (^)(JiveImage *))complete onError:(JiveErrorBlock) errorBlock;
+- (void)uploadPNGImage:(JiveNativeImage *)image onComplete:(void (^)(JiveImage *))complete onError:(JiveErrorBlock) errorBlock;
 
 //! https://developers.jivesoftware.com/api/v3/rest/ImageService.html#getContentImages(String,%20String)
 - (AFJSONRequestOperation<JiveRetryingOperation> *)imagesOperationFromURL:(NSURL *)imagesURL onComplete:(void (^)(NSArray *))complete onError:(JiveErrorBlock)error;
 //! https://developers.jivesoftware.com/api/v3/rest/ImageService.html#uploadImage(MultipartBody)
-- (AFHTTPRequestOperation<JiveRetryingOperation> *)uploadImageOperation:(UIImage*) image onComplete:(void (^)(JiveImage*))complete onError:(JiveErrorBlock) errorBlock;
+- (AFHTTPRequestOperation<JiveRetryingOperation> *)uploadImageOperation:(JiveNativeImage*) image onComplete:(void (^)(JiveImage*))complete onError:(JiveErrorBlock) errorBlock;
 //! https://developers.jivesoftware.com/api/v3/rest/ImageService.html#uploadImage(MultipartBody)
-- (AFHTTPRequestOperation<JiveRetryingOperation> *)uploadJPEGImageOperation:(UIImage *)image onComplete:(void (^)(JiveImage*))complete onError:(JiveErrorBlock) errorBlock;
+- (AFHTTPRequestOperation<JiveRetryingOperation> *)uploadJPEGImageOperation:(JiveNativeImage *)image onComplete:(void (^)(JiveImage*))complete onError:(JiveErrorBlock) errorBlock;
 //! https://developers.jivesoftware.com/api/v3/rest/ImageService.html#uploadImage(MultipartBody)
-- (AFHTTPRequestOperation<JiveRetryingOperation> *)uploadPNGImageOperation:(UIImage *)image onComplete:(void (^)(JiveImage*))complete onError:(JiveErrorBlock) errorBlock;
+- (AFHTTPRequestOperation<JiveRetryingOperation> *)uploadPNGImageOperation:(JiveNativeImage *)image onComplete:(void (^)(JiveImage*))complete onError:(JiveErrorBlock) errorBlock;
 
-- (AFImageRequestOperation<JiveRetryingOperation> *)imageRequestOperationWithMutableURLRequest:(NSMutableURLRequest *)imageMutableURLRequest onComplete:(void (^)(UIImage *))complete onError:(JiveErrorBlock)errorBlock;
+- (AFImageRequestOperation<JiveRetryingOperation> *)imageRequestOperationWithMutableURLRequest:(NSMutableURLRequest *)imageMutableURLRequest onComplete:(JiveImageCompleteBlock)complete onError:(JiveErrorBlock)errorBlock;
 
 #pragma mark - Outcomes
 //! No official documnetation yet.

--- a/jive-ios-sdk/Jive.m
+++ b/jive-ios-sdk/Jive.m
@@ -157,7 +157,7 @@ int const JivePushDeviceType = 3;
 - (AFJSONRequestOperation<JiveRetryingOperation> *)registerDeviceForJivePushNotifications:(NSString *)deviceToken onComplete:(JiveCompletedBlock)completeBlock onError:(JiveErrorBlock)errorBlock {
     NSMutableURLRequest *request = [self requestWithOptions:nil
                                                 andTemplate:@"api/core/mobile/v1/pushNotification/register", nil];
-    NSString *postString = [NSString stringWithFormat:@"deviceToken=%@&deviceType=%i&activated=true&featureFlags=%i", deviceToken, JivePushDeviceType, JVPushRegistrationFeatureFlagPush | JVPushRegistrationFeatureFlagVideo];
+    NSString *postString = [NSString stringWithFormat:@"deviceToken=%@&deviceType=%i&activated=true&featureFlags=%ti", deviceToken, JivePushDeviceType, JVPushRegistrationFeatureFlagPush | JVPushRegistrationFeatureFlagVideo];
     NSData *data = [postString dataUsingEncoding:NSUTF8StringEncoding];
     [request setHTTPBody:data];
     [request setHTTPMethod:@"POST"];
@@ -1277,7 +1277,7 @@ int const JivePushDeviceType = 3;
     [request setHTTPBody:body];
     [request setHTTPMethod:@"POST"];
     [request setValue:@"application/json; charset=UTF-8" forHTTPHeaderField:@"Content-Type"];
-    [request setValue:[NSString stringWithFormat:@"%i", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
+    [request setValue:[NSString stringWithFormat:@"%tu", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
     return [self entityOperationForClass:[JiveContent class]
                                  request:request
                               onComplete:complete
@@ -1420,7 +1420,7 @@ int const JivePushDeviceType = 3;
     [request setHTTPBody:body];
     [request setHTTPMethod:@"POST"];
     [request setValue:@"application/json; charset=UTF-8" forHTTPHeaderField:@"Content-Type"];
-    [request setValue:[NSString stringWithFormat:@"%i", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
+    [request setValue:[NSString stringWithFormat:@"%tu", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
     return [self entityOperationForClass:[JiveContent class]
                                  request:request
                               onComplete:completeBlock
@@ -1901,7 +1901,7 @@ int const JivePushDeviceType = 3;
     [request setHTTPBody:body];
     [request setHTTPMethod:@"POST"];
     [request setValue:@"application/json; charset=UTF-8" forHTTPHeaderField:@"Content-Type"];
-    [request setValue:[NSString stringWithFormat:@"%i", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
+    [request setValue:[NSString stringWithFormat:@"%tu", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
     return [self emptyOperationWithRequest:request onComplete:complete onError:error];
 }
 
@@ -1943,7 +1943,7 @@ int const JivePushDeviceType = 3;
     [request setHTTPMethod:@"PUT"];
     [request setHTTPBody:body];
     [request setValue:@"application/json; charset=UTF-8" forHTTPHeaderField:@"Content-Type"];
-    [request setValue:[NSString stringWithFormat:@"%i", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
+    [request setValue:[NSString stringWithFormat:@"%tu", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
     return [self entityOperationForClass:[JiveInvite class]
                                  request:request
                               onComplete:complete
@@ -1962,7 +1962,7 @@ int const JivePushDeviceType = 3;
     [request setHTTPMethod:@"POST"];
     [request setHTTPBody:body];
     [request setValue:@"application/json; charset=UTF-8" forHTTPHeaderField:@"Content-Type"];
-    [request setValue:[NSString stringWithFormat:@"%i", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
+    [request setValue:[NSString stringWithFormat:@"%tu", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
     return [self listOperationForClass:[JiveInvite class]
                                request:request
                             onComplete:complete
@@ -2153,7 +2153,7 @@ int const JivePushDeviceType = 3;
     void (^processPropsBlock)(NSArray* properties) = ^(NSArray* properties) {
         NSArray* relevantProps = [properties filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"name == %@", propertyName]];
         
-        NSAssert([relevantProps count] < 2, @"Expected one or zero properties for %@, but we got %i", propertyName, [relevantProps count]);
+        NSAssert([relevantProps count] < 2, @"Expected one or zero properties for %@, but we got %tu", propertyName, [relevantProps count]);
         
         if ([relevantProps count] == 1) {
             complete([relevantProps objectAtIndex:0]);
@@ -2214,7 +2214,7 @@ int const JivePushDeviceType = 3;
     [request setHTTPBody:body];
     [request setHTTPMethod:@"POST"];
     [request setValue:@"application/json; charset=UTF-8" forHTTPHeaderField:@"Content-Type"];
-    [request setValue:[NSString stringWithFormat:@"%i", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
+    [request setValue:[NSString stringWithFormat:@"%tu", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
     return request;
 }
 
@@ -2258,7 +2258,7 @@ int const JivePushDeviceType = 3;
     
     [request setHTTPBody:body];
     [request setValue:@"application/json; charset=UTF-8" forHTTPHeaderField:@"Content-Type"];
-    [request setValue:[NSString stringWithFormat:@"%i", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
+    [request setValue:[NSString stringWithFormat:@"%tu", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
     return request;
 }
 

--- a/jive-ios-sdk/Jive.m
+++ b/jive-ios-sdk/Jive.m
@@ -126,7 +126,9 @@ int const JivePushDeviceType = 3;
         _jiveInstance = jiveInstanceURL;
         self.delegate = delegate;
     }
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
     [[AFNetworkActivityIndicatorManager sharedManager] setEnabled:YES];
+#endif
     return self;
 }
 

--- a/jive-ios-sdk/JiveResponseBlocks.h
+++ b/jive-ios-sdk/JiveResponseBlocks.h
@@ -17,10 +17,18 @@
 //    limitations under the License.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 #ifndef jive_ios_sdk_JiveResponseBlocks_h
 #define jive_ios_sdk_JiveResponseBlocks_h
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+@class UIImage;
+@compatibility_alias JiveNativeImage UIImage;
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
+@class NSImage;
+@compatibility_alias JiveNativeImage NSImage;
+#endif
 
 @class JiveObject;
 @class JivePersonJive;
@@ -41,7 +49,7 @@ typedef void (^JiveArrayCompleteBlock)(NSArray *objects);
 typedef void (^JiveObjectCompleteBlock)(JiveObject *object);
 typedef void (^JivePersonCompleteBlock)(JivePerson *person);
 typedef void (^JiveBlogCompleteBlock)(JiveBlog *blogPlace);
-typedef void (^JiveImageCompleteBlock)(UIImage *avatarImage);
+typedef void (^JiveImageCompleteBlock)(JiveNativeImage *avatarImage);
 typedef void (^JiveTaskCompleteBlock)(JiveTask *task);
 typedef void (^JiveCompletedBlock)(void);
 typedef void (^JiveDateLimitedObjectsCompleteBlock)(NSArray *objects, NSDate *earliestDate, NSDate *latestDate);

--- a/jive-ios-sdk/JiveRetryingHTTPRequestOperation.m
+++ b/jive-ios-sdk/JiveRetryingHTTPRequestOperation.m
@@ -195,9 +195,11 @@
 /// @name Configuring Backgrounding Task Behavior
 ///----------------------------------------------
 
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 - (void)setShouldExecuteAsBackgroundTaskWithExpirationHandler:(void (^)(void))handler {
     [self.innerOperation setShouldExecuteAsBackgroundTaskWithExpirationHandler:handler];
 }
+#endif
 
 ///---------------------------------
 /// @name Setting Progress Callbacks

--- a/jive-ios-sdk/JiveRetryingImageRequestOperation.m
+++ b/jive-ios-sdk/JiveRetryingImageRequestOperation.m
@@ -195,9 +195,11 @@
 /// @name Configuring Backgrounding Task Behavior
 ///----------------------------------------------
 
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 - (void)setShouldExecuteAsBackgroundTaskWithExpirationHandler:(void (^)(void))handler {
     [self.innerOperation setShouldExecuteAsBackgroundTaskWithExpirationHandler:handler];
 }
+#endif
 
 ///---------------------------------
 /// @name Setting Progress Callbacks

--- a/jive-ios-sdk/JiveRetryingInnerJAPIRequestOperation.h
+++ b/jive-ios-sdk/JiveRetryingInnerJAPIRequestOperation.h
@@ -17,7 +17,6 @@
 //    limitations under the License.
 //
 
-#import <UIKit/UIKit.h>
 #import "JiveRetryingInnerHTTPRequestOperation.h"
 
 @class JAPIRequestOperation;

--- a/jive-ios-sdk/JiveRetryingJAPIRequestOperation.m
+++ b/jive-ios-sdk/JiveRetryingJAPIRequestOperation.m
@@ -201,9 +201,11 @@
 /// @name Configuring Backgrounding Task Behavior
 ///----------------------------------------------
 
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 - (void)setShouldExecuteAsBackgroundTaskWithExpirationHandler:(void (^)(void))handler {
     [self.innerOperation setShouldExecuteAsBackgroundTaskWithExpirationHandler:handler];
 }
+#endif
 
 ///---------------------------------
 /// @name Setting Progress Callbacks

--- a/jive-ios-sdk/JiveRetryingURLConnectionOperation.m
+++ b/jive-ios-sdk/JiveRetryingURLConnectionOperation.m
@@ -283,9 +283,11 @@
 /// @name Configuring Backgrounding Task Behavior
 ///----------------------------------------------
 
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
 - (void)setShouldExecuteAsBackgroundTaskWithExpirationHandler:(void (^)(void))handler {
     [self.operation setShouldExecuteAsBackgroundTaskWithExpirationHandler:handler];
 }
+#endif
 
 ///---------------------------------
 /// @name Setting Progress Callbacks

--- a/jive-ios-sdk/RequestOptions/JiveDefinedSizeRequestOptions.h
+++ b/jive-ios-sdk/RequestOptions/JiveDefinedSizeRequestOptions.h
@@ -17,7 +17,6 @@
 //    limitations under the License.
 //
 
-#import <UIKit/UIKit.h>
 #import "JiveRequestOptions.h"
 
 //! \enum JiveImageSizeOption

--- a/jive-ios-sdk/RequestOptions/JivePixelSizeRequestOptions.h
+++ b/jive-ios-sdk/RequestOptions/JivePixelSizeRequestOptions.h
@@ -17,7 +17,6 @@
 //    limitations under the License.
 //
 
-#import <UIKit/UIKit.h>
 #import "JiveRequestOptions.h"
 
 //! \class JivePixelSizeRequestOptions

--- a/jive-ios-sdk/RequestOptions/JiveReturnFieldsRequestOptions.h
+++ b/jive-ios-sdk/RequestOptions/JiveReturnFieldsRequestOptions.h
@@ -17,7 +17,6 @@
 //    limitations under the License.
 //
 
-#import <UIKit/UIKit.h>
 #import "JiveRequestOptions.h"
 
 //! \class JiveReturnFieldsRequestOptions

--- a/jive-ios-sdk/entity/JivePerson.m
+++ b/jive-ios-sdk/entity/JivePerson.m
@@ -431,7 +431,7 @@ NSString * const JivePersonType = @"person";
     
     [request setHTTPBody:body];
     [request setValue:@"application/json; charset=UTF-8" forHTTPHeaderField:@"Content-Type"];
-    [request setValue:[NSString stringWithFormat:@"%i", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
+    [request setValue:[NSString stringWithFormat:@"%tu", [[request HTTPBody] length]] forHTTPHeaderField:@"Content-Length"];
     [request setHTTPMethod:@"PUT"];
     return [self updateJiveTypedObject:self
                            withRequest:request
@@ -541,7 +541,7 @@ NSString * const JivePersonType = @"person";
     [request setHTTPBody:body];
     [request setHTTPMethod:@"POST"];
     [request setValue:@"application/json; charset=UTF-8" forHTTPHeaderField:@"Content-Type"];
-    [request setValue:[NSString stringWithFormat:@"%i", request.HTTPBody.length]
+    [request setValue:[NSString stringWithFormat:@"%tu", request.HTTPBody.length]
    forHTTPHeaderField:@"Content-Length"];
     return [self.jiveInstance listOperationForClass:[JiveStream class]
                                             request:request

--- a/jive-ios-sdk/jive-ios-sdk-Prefix.pch
+++ b/jive-ios-sdk/jive-ios-sdk-Prefix.pch
@@ -4,8 +4,13 @@
 
 #ifdef __OBJC__
 #import <Foundation/Foundation.h>
-#import <MobileCoreServices/MobileCoreServices.h>
 #import <SystemConfiguration/SystemConfiguration.h>
+
+#if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
+#import <MobileCoreServices/MobileCoreServices.h>
+#elif defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
+#import <CoreServices/CoreServices.h>
+#endif
 
 #import "AFHTTPClient.h"
 #import "AFHTTPRequestOperation.h"


### PR DESCRIPTION
Some developers might like to use `jive-ios-sdk` inside an OS X application.
